### PR TITLE
Fix worker capacity calculation

### DIFF
--- a/service/worker.go
+++ b/service/worker.go
@@ -260,8 +260,11 @@ func (w *worker) AddMessage(msg Message) error {
 
 // Capacity returns current message capacity and size
 func (w *worker) Capacity() (current int, size int) {
-	current = cap(w.messages)
 	size = w.size
+	current = size - len(w.messages)
+	if current < 0 {
+		current = 0
+	}
 	return
 }
 

--- a/service/worker_test.go
+++ b/service/worker_test.go
@@ -1,0 +1,38 @@
+package service
+
+import (
+	"io"
+	"log"
+	"testing"
+)
+
+func TestWorkerCapacity(t *testing.T) {
+	logger := log.New(io.Discard, "", 0)
+	wIface, err := NewWorker(logger, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	w := wIface.(*worker)
+	// reduce size for testing
+	w.messages = make(chan Message, 2)
+	w.results = make(chan Result, 2)
+	w.size = 2
+	w.state.Store(STATE_RUNNING)
+
+	current, size := w.Capacity()
+	if current != size {
+		t.Fatalf("expected capacity %d, got %d", size, current)
+	}
+
+	if err := w.AddMessage(Message{topic: "test", payload: []byte("1")}); err != nil {
+		t.Fatalf("unexpected add error: %v", err)
+	}
+
+	current, _ = w.Capacity()
+	if current != size-1 {
+		t.Fatalf("expected capacity %d, got %d", size-1, current)
+	}
+
+	w.Stop()
+}


### PR DESCRIPTION
## Summary
- fix `Capacity` to return remaining queue space
- add a unit test for worker capacity

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6849850cdcf08329b439ac457921b791