### PR TITLE
Fix mislabelled comments for DCMD and NBIRTH

### DIFF
--- a/sparkplug/command.go
+++ b/sparkplug/command.go
@@ -9,13 +9,13 @@ const (
 	DBIRTH Command = "DBIRTH"
 	// device data event
 	DDATA Command = "DDATA"
-	// device death event
+	// device command event
 	DCMD Command = "DCMD"
 	// device death event
 	DDEATH Command = "DDEATH"
 	// node command event
 	NCMD Command = "NCMD"
-	// device command event
+	// node birth event
 	NBIRTH Command = "NBIRTH"
 	// node data event
 	NDATA Command = "NDATA"


### PR DESCRIPTION
## Summary
- correct DCMD comment to "device command event"
- correct NBIRTH comment to "node birth event"

## Testing
- `go vet ./...` *(fails: toolchain download forbidden)*
- `go test ./...` *(fails: toolchain download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6849a34c31108329b3d4c02145e1dd7a