### PR TITLE
Add empty URL MQTT test

### DIFF
--- a/service/mqtt_test.go
+++ b/service/mqtt_test.go
@@ -54,6 +54,12 @@ func TestValidateMqttURL(t *testing.T) {
 			want:    false,
 			wantErr: true,
 		},
+		{
+			name:    "empty url",
+			args:    args{""},
+			want:    false,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- add empty url case to validateBrokerURI tests

## Testing
- `go test ./...` *(fails: forbidden downloading go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_6849a35337d88329be5dc8ee1774ad29